### PR TITLE
feat: migrate to manifest v3

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -1,0 +1,12 @@
+importScripts(
+  'constant.js',
+  'config.js',
+  'configUtil.js',
+  'option/receiver.js',
+  'observer.js',
+  'processor/setVisitPoint.js',
+  'processor/bookmark-sorter.js',
+  'processor/aggregate.js',
+  'processor/deleteBookmarks.js',
+  'trigger.js'
+);

--- a/background/processor/aggregate.js
+++ b/background/processor/aggregate.js
@@ -11,7 +11,7 @@ async function aggregate() {
         deleteSuggestionTargetsLength = deleteSuggestionTargets.length;
         let displayBadge = deleteSuggestionTargetsLength;
         if (displayBadge >= 1000) displayBadge = '999+'
-        chrome.browserAction.setBadgeText({ text: String(displayBadge) });
+        chrome.action.setBadgeText({ text: String(displayBadge) });
     } else { deleteSuggestionTargetsLength = 0; }
 };
 

--- a/background/trigger.js
+++ b/background/trigger.js
@@ -9,8 +9,8 @@ chrome.runtime.onInstalled.addListener(function () {
 	pusher(typeAggregate);
 });
 
-chrome.browserAction.onClicked.addListener(function () {
-	pusher(typeAggregate);
+chrome.action.onClicked.addListener(function () {
+        pusher(typeAggregate);
 });
 
 chrome.bookmarks.onCreated.addListener(function (id, bookmark) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-	"manifest_version": 2,
+        "manifest_version": 3,
 	"author": "Kazina",
 	"homepage_url": "https://github.com/KazinaG/Smart-Bookmark-Sorter",
 	"name": "Smart Bookmark Sorter",
 	"short_name": "SBS",
 	"description": "Frees you from organizing your bookmarks.",
-	"version": "2.4.2",
+        "version": "3.0.0",
 	"icons": {
 		"16": "SBS icon 16.png",
 		"32": "SBS icon 32.png",
@@ -13,27 +13,14 @@
 		"64": "SBS icon 64.png",
 		"128": "SBS icon 128.png"
 	},
-	"browser_action": {
-		"default_icon": "SBS icon 128.png",
-		"default_title": "Option",
-		"default_popup": "popup/html/option.html"
-	},
-	"background": {
-		"scripts": [
-			"background/jQuery/jQuery-3.4.1.js",
-			"background/constant.js",
-			"background/config.js",
-			"background/configUtil.js",
-			"background/option/receiver.js",
-			"background/observer.js",
-			"background/processor/setVisitPoint.js",
-			"background/processor/bookmark-sorter.js",
-			"background/processor/aggregate.js",
-			"background/processor/deleteBookmarks.js",
-			"background/trigger.js"
-		],
-		"persistent": false
-	},
+        "action": {
+                "default_icon": "SBS icon 128.png",
+                "default_title": "Option",
+                "default_popup": "popup/html/option.html"
+        },
+        "background": {
+                "service_worker": "background/background.js"
+        },
 	"permissions": [
 		"bookmarks",
 		"history",


### PR DESCRIPTION
## Summary
- migrate extension to Manifest V3 with service worker-based background script
- replace deprecated browserAction API usage with action
- add service worker entry script for background logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f2318448832b90eef7d69aceea94